### PR TITLE
[NVIDIA TF] Part 2: Fused matmul op supports cudnn matmul fusion

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3619,7 +3619,16 @@ tf_kernel_library(
         ":xsmm": ["@libxsmm_archive//:xsmm_avx"],
         "//conditions:default": [],
     }) + mkl_deps() + if_cuda([
+        ":conv_ops",
+        ":conv_ops_gpu_hdrs",
         ":matmul_util",
+        "//tensorflow/compiler/xla/stream_executor/gpu:gpu_asm_opts",
+        "//tensorflow/compiler/xla/stream_executor/gpu:redzone_allocator",
+        "//tensorflow/compiler/xla/stream_executor:tf_allocator_adapter",
+        "//tensorflow/core/profiler/lib:scoped_annotation",
+        "//tensorflow/core/protobuf:autotuning_proto_cc",
+        "//tensorflow/core/util/autotune_maps:conv_parameters",
+        "//tensorflow/core/util/proto:proto_utils",
         "//tensorflow/tsl/platform/default/build_config:cublas_plugin",
     ]) + if_cuda_or_rocm([
         ":gpu_utils",

--- a/tensorflow/core/kernels/conv_ops_fused_impl.h
+++ b/tensorflow/core/kernels/conv_ops_fused_impl.h
@@ -257,9 +257,6 @@ struct LaunchFusedConv2DOp<CPUDevice, T> {
       case FusedComputationType::kUndefined:
         OP_REQUIRES_OK(context, errors::Internal("Fusion type is undefined"));
         break;
-      case FusedComputationType::kBiasAddWithGeluApproximate:
-        OP_REQUIRES_OK(context, errors::Internal("Fusion type is unsupported"));
-        break;
       case FusedComputationType::kBiasAdd:
         conv2d(WithBiasAdd<T>(bias_add_args), context, input, filter, output);
         break;
@@ -303,6 +300,9 @@ struct LaunchFusedConv2DOp<CPUDevice, T> {
         conv2d(WithFusedBatchNormAndElu<T>(fusion_args.epsilon,
                                            fused_batch_norm_args),
                context, input, filter, output);
+        break;
+      default:
+        OP_REQUIRES_OK(context, errors::Internal("Fusion type is unsupported"));
         break;
     }
   }

--- a/tensorflow/core/kernels/fused_eigen_output_kernels.cc
+++ b/tensorflow/core/kernels/fused_eigen_output_kernels.cc
@@ -62,7 +62,8 @@ Status InitializeFusedComputation(
       *fused_computation == FusedComputationType::kBiasAddWithRelu6 ||
       *fused_computation == FusedComputationType::kBiasAddWithElu ||
       *fused_computation == FusedComputationType::kBiasAddWithLeakyRelu ||
-      *fused_computation == FusedComputationType::kBiasAddWithGeluApproximate) {
+      *fused_computation == FusedComputationType::kBiasAddWithGeluApproximate ||
+      *fused_computation == FusedComputationType::kBiasAddWithGeluExact) {
     if (num_args != 1) {
       return errors::InvalidArgument(
           "Fused ", kernel_name,

--- a/tensorflow/core/kernels/fused_eigen_output_kernels.h
+++ b/tensorflow/core/kernels/fused_eigen_output_kernels.h
@@ -41,6 +41,7 @@ enum class FusedComputationType {
   kBiasAddWithElu,
   kBiasAddWithLeakyRelu,
   kBiasAddWithGeluApproximate,
+  kBiasAddWithGeluExact,
   kFusedBatchNorm,
   kFusedBatchNormWithRelu,
   kFusedBatchNormWithRelu6,

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -225,6 +225,51 @@ void LogFusedConvForwardAutotuneResults(
   Logger::GetSingleton()->LogProto(log);
 }
 
+void LogFusedMatmulAutotuneResults(
+    se::dnn::DataType ab_dtype, se::dnn::DataType c_dtype,
+    se::DeviceMemoryBase a_buffer, se::DeviceMemoryBase b_buffer,
+    se::DeviceMemoryBase c_buffer, se::DeviceMemoryBase bias_buffer,
+    bool trans_a, bool trans_b, uint32_t m, uint32_t n, uint32_t k, int32_t lda,
+    int32_t ldb, int32_t ldc, se::dnn::ActivationMode activation_mode,
+    se::StreamExecutor* stream_exec, absl::Span<const AutotuneResult> results) {
+  AutotuningLog log;
+  {
+    MatmulProto instr;
+    instr.set_ab_dtype(ab_dtype);
+    instr.set_c_dtype(c_dtype);
+    instr.set_trans_a(trans_a);
+    instr.set_trans_b(trans_b);
+    instr.set_m(m);
+    instr.set_n(n);
+    instr.set_k(k);
+    instr.set_lda(lda);
+    instr.set_ldb(ldb);
+    instr.set_ldc(ldc);
+    instr.set_activation(activation_mode);
+    instr.set_a_address(reinterpret_cast<uint64>(a_buffer.opaque()));
+    instr.set_b_address(reinterpret_cast<uint64>(b_buffer.opaque()));
+    instr.set_c_address(reinterpret_cast<uint64>(c_buffer.opaque()));
+    instr.set_bias_address(reinterpret_cast<uint64>(bias_buffer.opaque()));
+    log.mutable_instr()->PackFrom(std::move(instr));
+  }
+  *log.mutable_cudnn_version() = GetCudnnVersion(stream_exec);
+  *log.mutable_compute_capability() = GetComputeCapability(stream_exec);
+  log.set_device_pci_bus_id(stream_exec->GetDeviceDescription().pci_bus_id());
+  {
+    string blas_version;
+    if (auto* blas = stream_exec->AsBlas()) {
+      if (blas->GetVersion(&blas_version).ok()) {
+        log.set_blas_version(blas_version);
+      }
+    }
+  }
+  for (const auto& result : results) {
+    *log.add_results() = result;
+  }
+  VLOG(2) << log.DebugString();
+  Logger::GetSingleton()->LogProto(log);
+}
+
 namespace {
 StatusOr<std::tuple<int, int>> BestCudnnConvAlgorithmIndices(
     absl::Span<const AutotuneResult> results) {
@@ -326,6 +371,13 @@ BestCudnnConvAlgorithm<se::dnn::FusedConvOp>(
     absl::Span<const AutotuneResult> results,
     std::vector<
         std::unique_ptr<const se::dnn::OpRunner<se::dnn::FusedConvSignature>>>
+        runners);
+
+template StatusOr<AutotuneEntry<se::dnn::FusedMatmulOp>>
+BestCudnnConvAlgorithm<se::dnn::FusedMatmulOp>(
+    absl::Span<const AutotuneResult> results,
+    std::vector<
+        std::unique_ptr<const se::dnn::OpRunner<se::dnn::FusedMatmulSignature>>>
         runners);
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/gpu_utils.h
+++ b/tensorflow/core/kernels/gpu_utils.h
@@ -277,6 +277,15 @@ void LogFusedConvForwardAutotuneResults(
     double side_value_scale, se::dnn::ActivationMode activation_mode,
     se::StreamExecutor* stream_exec, absl::Span<const AutotuneResult> results);
 
+// Logs fused matmul results to customized back-storage.
+void LogFusedMatmulAutotuneResults(
+    se::dnn::DataType ab_dtype, se::dnn::DataType c_dtype,
+    se::DeviceMemoryBase a_buffer, se::DeviceMemoryBase b_buffer,
+    se::DeviceMemoryBase c_buffer, se::DeviceMemoryBase bias_buffer,
+    bool trans_a, bool trans_b, uint32_t m, uint32_t n, uint32_t k, int32_t lda,
+    int32_t ldb, int32_t ldc, se::dnn::ActivationMode activation_mode,
+    se::StreamExecutor* stream_exec, absl::Span<const AutotuneResult> results);
+
 // Autotuning map entry for cuDNN-frontend-capable APIs.
 //
 // The longer-term intent is to remove the AlgorithmConfig variant and make this

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -52,11 +52,20 @@ limitations under the License.
 #endif
 
 #if GOOGLE_CUDA
+#include "tensorflow/compiler/xla/stream_executor/gpu/gpu_asm_opts.h"
+#include "tensorflow/compiler/xla/stream_executor/gpu/redzone_allocator.h"
+#include "tensorflow/compiler/xla/stream_executor/tf_allocator_adapter.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
 #include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/kernels/matmul_op_impl.h"
 #include "tensorflow/core/kernels/matmul_util.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/tensor_float_32_utils.h"
+#include "tensorflow/core/profiler/lib/scoped_annotation.h"
+#include "tensorflow/core/protobuf/autotuning.pb.h"
+#include "tensorflow/core/util/autotune_maps/conv_parameters.h"
+#include "tensorflow/core/util/proto/proto_utils.h"
+#include "tensorflow/core/util/use_cudnn.h"
 #endif  // GOOGLE_CUDA
 
 namespace tensorflow {
@@ -231,6 +240,172 @@ se::blas::AlgorithmConfig AutotuneMatmul(
   return algorithm_config;
 }
 
+template <typename LaunchFunc, typename Sig>
+StatusOr<std::vector<tensorflow::AutotuneResult>> AutotuneMatMulImpl(
+    OpKernelContext* ctx,
+    std::vector<std::unique_ptr<const se::dnn::OpRunner<Sig>>>& runners,
+    bool actually_do_autotune, const LaunchFunc& launch_func,
+    size_t scratch_size_limit, const se::RedzoneAllocator& rz_allocator) {
+  auto* stream = ctx->op_device_context()->stream();
+
+  se::TfAllocatorAdapter tf_allocator_adapter(ctx->device()->GetAllocator({}),
+                                              stream);
+
+  std::vector<tensorflow::AutotuneResult> results;
+  results.reserve(runners.size());
+  // TODO(reedwm): Warn if determinism is enabled after autotune is run
+  for (auto& runner : runners) {
+    // TODO(zhengxq): profile each algorithm multiple times to better
+    // accuracy.
+    se::RedzoneAllocator rz_scratch_allocator(
+        stream, &tf_allocator_adapter, se::GpuAsmOpts(),
+        /*memory_limit=*/scratch_size_limit);
+    BlasScratchAllocator scratch_allocator(ctx, scratch_size_limit);
+    se::ScratchAllocator* allocator_used =
+        !RedzoneCheckDisabled()
+            ? static_cast<se::ScratchAllocator*>(&rz_scratch_allocator)
+            : static_cast<se::ScratchAllocator*>(&scratch_allocator);
+
+    TF_ASSIGN_OR_RETURN(auto desc, runner->ToAlgorithmDesc());
+    se::dnn::ProfileResult profile_result;
+    Status cudnn_launch_status =
+        actually_do_autotune
+            ? launch_func(allocator_used, runner, &profile_result)
+            : OkStatus();
+    if (!actually_do_autotune) {
+      // Make the result valid according to `is_valid`.
+      profile_result.set_algorithm(desc);
+      profile_result.set_elapsed_time_in_ms(0);
+    }
+
+    // We need to make sure the profiling results are one-to-one with the
+    // "runners". So, we insert dummy results when the execution fails.
+    results.emplace_back();
+    auto& result = results.back();
+    *result.mutable_algorithm() = desc.ToProto();
+    if (cudnn_launch_status.ok() && profile_result.is_valid()) {
+      result.set_scratch_bytes(
+          !RedzoneCheckDisabled()
+              ? rz_scratch_allocator.TotalAllocatedBytesExcludingRedzones()
+              : scratch_allocator.TotalByteSize());
+      *result.mutable_run_time() = proto_utils::ToDurationProto(
+          absl::Milliseconds(profile_result.elapsed_time_in_ms()));
+
+      CheckRedzones(rz_scratch_allocator, &result);
+      CheckRedzones(rz_allocator, &result);
+    } else {
+      result.mutable_failure()->set_kind(AutotuneResult::UNKNOWN);
+      result.mutable_failure()->set_msg(
+          absl::StrCat("Profiling failure on CUDNN engine ", desc.ToString(),
+                       ": ", cudnn_launch_status.ToString()));
+    }
+  }
+
+  return results;
+}
+
+struct FusedMatmulAutotuneGroup {
+  static string name() { return "FusedMatmul"; }
+};
+
+typedef AutotuneSingleton<FusedMatmulAutotuneGroup, MatmulParameters,
+                          AutotuneEntry<se::dnn::FusedMatmulOp>>
+    FusedMatmulAutotuneMap;
+
+template <typename T>
+StatusOr<AutotuneEntry<se::dnn::FusedMatmulOp>> AutotuneFusedMatmul(
+    bool cudnn_use_autotune,
+    AutotuneMap<MatmulParameters, AutotuneEntry<se::dnn::FusedMatmulOp>>*
+        autotune_map,
+    const MatmulParameters& params, OpKernelContext* ctx, bool trans_a,
+    bool trans_b, uint64_t m, uint64_t n, uint64_t k, int64_t lda, int64_t ldb,
+    int64_t ldc, se::dnn::ActivationMode activation_mode,
+    se::DeviceMemory<T> a_ptr, se::DeviceMemory<T> b_ptr,
+    se::DeviceMemory<T> c_ptr, se::DeviceMemory<T> bias_ptr,
+    int64_t scratch_size_limit) {
+  AutotuneEntry<se::dnn::FusedMatmulOp> autotune_entry;
+  auto* stream = ctx->op_device_context()->stream();
+
+  if (!autotune_map->Find(params, &autotune_entry)) {
+    profiler::ScopedAnnotation trace("cudnn_autotuning");
+
+    se::TfAllocatorAdapter tf_allocator_adapter(ctx->device()->GetAllocator({}),
+                                                stream);
+    se::RedzoneAllocator rz_allocator(stream, &tf_allocator_adapter,
+                                      se::GpuAsmOpts());
+    se::DeviceMemory<T> c_ptr_rz(WrapRedzoneBestEffort(&rz_allocator, c_ptr));
+
+    std::vector<std::unique_ptr<const se::dnn::FusedMatmulRunner>> runners;
+    auto element_type = se::dnn::ToDataType<T>::value;
+    TF_RETURN_IF_ERROR(stream->parent()->GetFusedMatmulRunners(
+        CudnnUseFrontend(), element_type, element_type, element_type, stream,
+        trans_a, trans_b, m, n, k, lda, ldb, ldc, activation_mode,
+        /*use_fallback=*/false, &runners));
+
+    auto launch_func =
+        [&](se::ScratchAllocator* allocator_used,
+            const std::unique_ptr<const se::dnn::FusedMatmulRunner>& runner,
+            se::dnn::ProfileResult* profile_result) -> Status {
+      TF_ASSIGN_OR_RETURN(auto scratch, allocator_used->AllocateBytes(
+                                            runner->GetWorkspaceSize()));
+      return (*runner)(stream, profile_result, scratch, a_ptr, b_ptr, bias_ptr,
+                       c_ptr_rz);
+    };
+
+    TF_ASSIGN_OR_RETURN(
+        auto results,
+        AutotuneMatMulImpl(ctx, runners, cudnn_use_autotune, launch_func,
+                           scratch_size_limit, rz_allocator));
+    // Only log on an AutotuneConv cache miss.
+    LogFusedMatmulAutotuneResults(element_type, element_type, a_ptr, b_ptr,
+                                  c_ptr, bias_ptr, trans_a, trans_b, m, n, k,
+                                  lda, ldb, ldc, activation_mode,
+                                  stream->parent(), results);
+
+    // Two-level autotuning: Cudnn frontend supports two engine lists:
+    // heuristics and fallback. Heuristics engines are normally faster.
+    // To reduce autotuning time, we evaluate the fallback engines only when
+    // none of the heuristics engines work.
+    const bool found_working_engine =
+        std::any_of(results.cbegin(), results.cend(),
+                    [](const auto& result) { return !result.has_failure(); });
+
+    if (found_working_engine) {
+      TF_ASSIGN_OR_RETURN(autotune_entry,
+                          BestCudnnConvAlgorithm<se::dnn::FusedMatmulOp>(
+                              results, std::move(runners)));
+    } else {
+      LOG(WARNING)
+          << "None of the algorithms provided by cuDNN frontend heuristics "
+             "worked; trying fallback algorithms.  Matmul: "
+          << params.ToString();
+      std::vector<std::unique_ptr<const se::dnn::FusedMatmulRunner>>
+          fallback_runners;
+      TF_RETURN_IF_ERROR(stream->parent()->GetFusedMatmulRunners(
+          CudnnUseFrontend(), element_type, element_type, element_type, stream,
+          trans_a, trans_b, m, n, k, lda, ldb, ldc, activation_mode,
+          /*use_fallback=*/true, &fallback_runners));
+
+      TF_ASSIGN_OR_RETURN(
+          auto fallback_results,
+          AutotuneMatMulImpl(ctx, fallback_runners, cudnn_use_autotune,
+                             launch_func, scratch_size_limit, rz_allocator));
+
+      LogFusedMatmulAutotuneResults(element_type, element_type, a_ptr, b_ptr,
+                                    c_ptr, bias_ptr, trans_a, trans_b, m, n, k,
+                                    lda, ldb, ldc, activation_mode,
+                                    stream->parent(), fallback_results);
+
+      TF_ASSIGN_OR_RETURN(autotune_entry,
+                          BestCudnnConvAlgorithm<se::dnn::FusedMatmulOp>(
+                              fallback_results, std::move(fallback_runners)));
+    }
+
+    autotune_map->Insert(params, autotune_entry);
+  }
+  return autotune_entry;
+}
+
 }  // namespace
 
 template <typename T>
@@ -266,16 +441,84 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     auto c_ptr = AsDeviceMemory(output->template flat<T>().data(),
                                 output->template flat<T>().size());
 
-    auto epilog_op_or = GetBlasLtEpilogOp(fusion);
-    OP_REQUIRES_OK(context, epilog_op_or.status());
-    se::cuda::BlasLt::Epilogue epilog_op = epilog_op_or.ValueOrDie();
-
     bool trans_a = dim_pair[0].first == 0 ? true : false;
     bool trans_b = dim_pair[0].second == 1 ? true : false;
 
     const int64_t m = a.dim_size(trans_a ? 1 : 0);
     const int64_t k = a.dim_size(trans_a ? 0 : 1);
     const int64_t n = b.dim_size(trans_b ? 0 : 1);
+
+    bool use_cudnn = false;
+    se::dnn::ActivationMode matmul_activation_mode;
+    switch (fusion) {
+      case FusedComputationType::kBiasAddWithGeluExact:
+        matmul_activation_mode = se::dnn::ActivationMode::kGeluExact;
+        use_cudnn = true;
+        break;
+      default:
+        use_cudnn = false;
+    }
+
+    BlasScratchAllocator scratch_allocator(context);
+
+    // The Gelu exact fusion is supported by the cuDNN.
+    if (use_cudnn) {
+      int device_id = stream->parent()->device_ordinal();
+      DataType ab_dtype = a.dtype();
+      DataType c_dtype = output->dtype();
+      MatmulParameters cudnn_matmul_params = {/*ab_type=*/ab_dtype,
+                                              /*c_type=*/c_dtype,
+                                              trans_a,
+                                              trans_b,
+                                              static_cast<uint64_t>(m),
+                                              static_cast<uint64_t>(n),
+                                              static_cast<uint64_t>(k),
+                                              a.dim_size(1),
+                                              b.dim_size(1),
+                                              output->dim_size(1),
+                                              matmul_activation_mode,
+                                              device_id};
+
+      auto entry_or = AutotuneFusedMatmul<T>(
+          use_autotune, FusedMatmulAutotuneMap::GetInstance(),
+          cudnn_matmul_params, context, trans_a, trans_b, m, n, k,
+          a.dim_size(1), b.dim_size(1), output->dim_size(1),
+          matmul_activation_mode, a_ptr, b_ptr, c_ptr, bias_ptr,
+          GetDnnWorkspaceLimitOrDefault());
+      OP_REQUIRES_OK(context, entry_or.status());
+      auto autotune_entry = std::move(entry_or).value();
+
+      auto& runners = autotune_entry.GetOpRunners();
+      se::dnn::FusedMatmulOp::Config config;
+      auto primary_or = runners.primary->GetOrCreateRunner(config, stream);
+      OP_REQUIRES_OK(context, primary_or.status());
+      auto* primary = primary_or.ValueOrDie();
+
+      const se::dnn::FusedMatmulRunner* no_scratch_fallback = nullptr;
+      if (runners.no_scratch_fallback) {
+        auto no_scratch_fallback_or =
+            runners.no_scratch_fallback->GetOrCreateRunner(config, stream);
+        OP_REQUIRES_OK(context, no_scratch_fallback_or.status());
+        no_scratch_fallback = no_scratch_fallback_or.ValueOrDie();
+      }
+
+      auto runner_and_scratch_or =
+          AllocateScratchOrFallback<se::dnn::FusedMatmulOp::Signature>(
+              &scratch_allocator, primary, no_scratch_fallback);
+      OP_REQUIRES_OK(context, runner_and_scratch_or.status());
+      auto runner_and_scratch = std::move(runner_and_scratch_or).value();
+      auto& runner =
+          *std::get<const se::dnn::FusedMatmulRunner*>(runner_and_scratch);
+      Status cudnn_launch_status = runner(
+          stream, nullptr, std::get<se::DeviceMemoryBase>(runner_and_scratch),
+          a_ptr, b_ptr, bias_ptr, c_ptr);
+      OP_REQUIRES_OK(context, cudnn_launch_status);
+      return;
+    }
+
+    auto epilog_op_or = GetBlasLtEpilogOp(fusion);
+    OP_REQUIRES_OK(context, epilog_op_or.status());
+    se::cuda::BlasLt::Epilogue epilog_op = epilog_op_or.ValueOrDie();
 
     se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                    se::blas::Transpose::kTranspose};
@@ -315,7 +558,6 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
       algorithm = algorithms[algorithm_idx];
     }
 
-    BlasScratchAllocator scratch_allocator(context);
     OP_REQUIRES_OK(context, launch_func(scratch_allocator, algorithm, nullptr));
   }
 };
@@ -344,12 +586,19 @@ class FusedMatMulOp : public OpKernel {
       patterns = {
           {FCT::kBiasAdd, {"BiasAdd"}},
           {FCT::kBiasAddWithRelu, {"BiasAdd", "Relu"}},
-          {FCT::kBiasAddWithGeluApproximate, {"BiasAdd", "GeluApproximate"}}};
+          {FCT::kBiasAddWithGeluApproximate, {"BiasAdd", "GeluApproximate"}},
+          {FCT::kBiasAddWithGeluExact, {"BiasAdd", "GeluExact"}}};
     }
 
     OP_REQUIRES_OK(context, InitializeFusedComputation(
                                 context, "MatMul", patterns,
                                 &fused_computation_, &fused_computation_args_));
+    if (std::is_same<Device, GPUDevice>::value &&
+        fused_computation_ == FCT::kBiasAddWithGeluExact) {
+      OP_REQUIRES(context, DataTypeToEnum<T>::value == DT_HALF,
+                  errors::InvalidArgument("Matmul with BiasAdd+GeluExact "
+                                          "supports only DT_HALF data type."));
+    }
     use_autotune_ = MatmulAutotuneEnable();
   }
 

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -337,11 +337,13 @@ class BlasScratchAllocator : public se::ScratchAllocator {
     // Hold the reference of the allocated tensors until the end of the
     // allocator.
     allocated_tensors_.push_back(temporary_memory);
+    total_byte_size_ += byte_size;
     return se::port::StatusOr<DeviceMemoryBytes>(
         DeviceMemoryBytes::MakeFromByteSize(
             temporary_memory.flat<uint8>().data(),
             temporary_memory.flat<uint8>().size()));
   }
+  int64 TotalByteSize() { return total_byte_size_; }
 
  private:
   int64_t memory_limit_;

--- a/tensorflow/core/protobuf/conv_autotuning.proto
+++ b/tensorflow/core/protobuf/conv_autotuning.proto
@@ -31,3 +31,24 @@ message ConvolutionProto {
   int64 bias_address = 12;
   int64 side_input_address = 13;
 }
+
+message MatmulProto {
+  stream_executor.dnn.DataType ab_dtype = 1;
+  stream_executor.dnn.DataType c_dtype = 2;
+
+  bool trans_a = 3;
+  bool trans_b = 4;
+  uint64 m = 5;
+  uint64 n = 6;
+  uint64 k = 7;
+  int64 lda = 8;
+  int64 ldb = 9;
+  int64 ldc = 10;
+
+  stream_executor.dnn.ActivationMode activation = 11;
+
+  int64 a_address = 12;
+  int64 b_address = 13;
+  int64 c_address = 14;
+  int64 bias_address = 15;
+}

--- a/tensorflow/core/util/autotune_maps/conv_parameters.h
+++ b/tensorflow/core/util/autotune_maps/conv_parameters.h
@@ -89,6 +89,43 @@ class ConvParameters {
   ConvParametersProto proto_;
   uint64 hash_code_;
 };
+
+class MatmulParameters {
+ public:
+  // LINT.IfChange(matmul_parameters_version)
+  // A positive number that denotes the version of this class. Should be
+  // incremented everytime this class or ConvParametersProto are updated in a
+  // way that may invalidate autotune results.
+  static constexpr int kVersion = 1;
+  // LINT.ThenChange()
+
+  MatmulParameters(DataType ab_dtype, DataType c_dtype, bool trans_a,
+                   bool trans_b, uint64_t m, uint64_t n, uint64_t k,
+                   int64_t lda, int64_t ldb, int64_t ldc,
+                   stream_executor::dnn::ActivationMode activation_mode,
+                   int device_id,
+                   // This argument should be set only for test use.
+                   int version = kVersion);
+
+  MatmulParameters(int device_id, const MatmulParametersProto& proto);
+
+  bool operator==(const MatmulParameters& other) const;
+
+  bool operator!=(const MatmulParameters& other) const {
+    return !(*this == other);
+  }
+  uint64 hash() const { return hash_code_; }
+
+  string ToString() const;
+
+  const MatmulParametersProto& proto() const { return proto_; }
+
+ private:
+  int device_id_;
+  MatmulParametersProto proto_;
+  uint64 hash_code_;
+};
+
 }  // namespace tensorflow
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 

--- a/tensorflow/core/util/autotune_maps/conv_parameters.proto
+++ b/tensorflow/core/util/autotune_maps/conv_parameters.proto
@@ -77,3 +77,26 @@ message ConvParametersProto {
 //  LINT.ThenChange(
 //  "conv_parameters.h:conv_parameters_version"
 //  )
+
+// LINT.IfChange
+
+message MatmulParametersProto {
+  tensorflow.DataType ab_dtype = 1;
+  tensorflow.DataType c_dtype = 2;
+  bool trans_a = 3;
+  bool trans_b = 4;
+  uint64 m = 5;
+  uint64 n = 6;
+  uint64 k = 7;
+  int64 lda = 8;
+  int64 ldb = 9;
+  int64 ldc = 10;
+  stream_executor.dnn.ActivationMode activation_mode = 11;
+
+  string device_identifier = 12;
+  int32 version = 14;
+}
+
+//  LINT.ThenChange(
+//  "conv_parameters.h:matmul_parameters_version"
+//  )


### PR DESCRIPTION
This PR enables the cudnn matmul fusion backend for supporting the generic matmul fusion patterns. Specifically, this PR focuses on the matmul+bias+gelu_exact pattern. (Note, the matmul+bias+gelu_approximate has already been supported by cublasLt backend. See https://github.com/tensorflow/tensorflow/pull/55966)

Part 1: Stream executor supports cudnn matmul fusion.
Part 2: Fused matmul op supports cudnn matmul fusion. (This one)
Part 3: Grappler graph pass supports matmul+bias+gelu_exact.

cc. @nluehr @pjannaty 